### PR TITLE
Add connector setup guides, resilient GitHub polling, and docs

### DIFF
--- a/agents/ciso.json
+++ b/agents/ciso.json
@@ -1,11 +1,11 @@
 {
   "id": "ciso",
   "name": "CISO",
-  "description": "Monitors GitHub and Slack for security vulnerabilities, dependency risks, secrets exposure, CI/CD security gaps, and incident signals. Produces daily security briefs and weekly reviews.",
+  "description": "Monitors GitHub and Slack for security vulnerabilities, dependency risks, secrets exposure, CI/CD security gaps, deployments, releases, and incident signals. Produces daily security briefs and weekly reviews.",
   "subscriptions": [
     {
       "source": "github",
-      "eventTypes": ["pr.*", "push.*", "build.*", "issue.*", "review.*", "comment.*"]
+      "eventTypes": ["pr.*", "commit.*", "build.*", "deploy.*", "release.*", "issue.*"]
     },
     {
       "source": "slack",

--- a/agents/design-manager.json
+++ b/agents/design-manager.json
@@ -1,7 +1,7 @@
 {
   "id": "design-manager",
   "name": "Design Manager",
-  "description": "Watches Figma activity, design discussions on Slack, and GitHub for design-related PRs. Tracks design velocity, collaboration, and system health.",
+  "description": "Watches Figma activity, design discussions on Slack, and GitHub releases and deployments. Tracks design velocity, collaboration, and what's shipping.",
   "subscriptions": [
     {
       "source": "figma",
@@ -13,7 +13,7 @@
     },
     {
       "source": "github",
-      "eventTypes": ["pr.opened", "pr.merged"]
+      "eventTypes": ["release.*", "deploy.*"]
     }
   ],
   "persona": {

--- a/agents/eng-manager.json
+++ b/agents/eng-manager.json
@@ -1,11 +1,11 @@
 {
   "id": "eng-manager",
   "name": "Engineering Manager",
-  "description": "Watches GitHub PRs, builds, and Slack engineering channels. Produces daily standups and weekly summaries focused on shipping velocity, code quality, and team health.",
+  "description": "Watches GitHub PRs, builds, deployments, releases, and Slack engineering channels. Produces daily standups and weekly summaries focused on shipping velocity, code quality, and team health.",
   "subscriptions": [
     {
       "source": "github",
-      "eventTypes": ["pr.*", "review.*", "comment.*", "build.*", "push.*", "issue.*"]
+      "eventTypes": ["pr.*", "commit.*", "build.*", "deploy.*", "release.*", "issue.*"]
     },
     {
       "source": "slack",

--- a/agents/product-manager.json
+++ b/agents/product-manager.json
@@ -9,7 +9,7 @@
     },
     {
       "source": "github",
-      "eventTypes": ["pr.merged", "pr.opened", "issue.*"]
+      "eventTypes": ["pr.merged", "pr.opened", "issue.*", "release.*", "deploy.*"]
     },
     {
       "source": "intercom",

--- a/workers/connectors/github/CLAUDE.md
+++ b/workers/connectors/github/CLAUDE.md
@@ -21,7 +21,7 @@ A cron trigger (`0 */6 * * *`) calls `pollAllRepos()` which:
 
 1. Reads the list of repos from `GITHUB_REPOS` (comma-separated)
 2. Authenticates as a GitHub App using RS256 JWT → installation access token
-3. Fetches PRs, reviews, issues, commits, comments, and workflow runs via GitHub API
+3. Fetches PRs, reviews, issues, commits, comments, workflow runs, deployments, and releases via GitHub API
 4. Uses KV (`POLL_CURSOR`) to track the last-seen timestamp per repo (defaults to 30 days back on first run)
 5. Slims payloads to essential fields before normalizing (to stay under queue message size limits)
 6. Publishes all normalized events to the queue
@@ -44,11 +44,14 @@ Polling catches events that webhooks might miss (downtime, misconfiguration) and
 |-------------|---------------------|--------------|
 | `pull_request` | `pr.opened`, `pr.closed`, `pr.merged`, `pr.updated` | additions, deletions, draft, labels, reviewers |
 | `pull_request_review` | `pr.review.submitted` | state (approved/changes_requested), time-to-review hours |
+| `pull_request_review_comment` | `pr.review.comment` | file path, word count |
 | `issues` | `issue.opened`, `issue.closed`, `issue.updated` | number, title, labels, age in hours |
 | `issue_comment` | `issue.comment.created` | word count, body preview |
-| `pull_request_review_comment` | `pr.review.comment` | file path, word count |
 | `push` | `commit.pushed` | commit count, branch |
-| `workflow_run` | `build.completed` | conclusion (success/failure), branch |
+| `workflow_run` | `build.succeeded`, `build.failed`, `build.{conclusion}` | conclusion, branch, triggering actor |
+| `deployment` | `deploy.{action}` | environment, ref, description |
+| `deployment_status` | `deploy.succeeded`, `deploy.failed`, `deploy.{state}` | environment, state, target URL |
+| `release` | `release.published`, `release.prereleased`, `release.{action}` | tag name, draft/prerelease flags, body preview |
 
 ## Endpoints
 
@@ -99,8 +102,8 @@ All secrets are set via `wrangler secret put <NAME>`:
 1. Go to **GitHub org Settings → Developer settings → GitHub Apps → New GitHub App**
 2. Set the **Webhook URL** to this worker's URL (e.g. `https://openchief-connector-github.your-team.workers.dev`)
 3. Generate a **Webhook Secret** (`openssl rand -hex 20`) and enter it
-4. **Repository permissions** (all Read-only): Commit statuses, Contents, Issues, Metadata, Pull requests
-5. **Subscribe to events**: Create, Delete, Issue comment, Issues, Pull request, Pull request review, Push, Status
+4. **Repository permissions** (all Read-only): Actions, Commit statuses, Contents, Deployments, Issues, Metadata, Pull requests
+5. **Subscribe to events**: Create, Delete, Deployment, Deployment status, Issue comment, Issues, Pull request, Pull request review, Pull request review comment, Push, Release, Status, Workflow run
 6. Select **"Only on this account"**, click Create
 7. Note the **App ID** from the settings page
 8. **Generate a private key** → download `.pem` → convert to PKCS#8
@@ -117,8 +120,9 @@ Create a new GitHub App for OpenChief on my organization. Navigate to GitHub →
 Organization Settings → Developer Settings → GitHub Apps → New. Fill in the app
 name, set the webhook URL to my GitHub connector worker URL, generate a webhook
 secret, set repository permissions (Commit statuses, Contents, Issues, Pull
-requests — all Read-only), subscribe to events (Create, Delete, Issue comment,
-Issues, Pull request, Pull request review, Push, Status), select Only on this
+Actions, Deployments — all Read-only), subscribe to events (Create, Delete,
+Deployment, Deployment status, Issue comment, Issues, Pull request, Pull request
+review, Pull request review comment, Push, Release, Status, Workflow run), select Only on this
 account, create the app, generate a private key, install it on the org for all
 repos, then convert the private key to PKCS#8 and set all the wrangler secrets
 on the connector worker.
@@ -130,4 +134,4 @@ on the connector worker.
 - Payloads are slimmed before normalization to stay under queue message size limits (~128KB)
 - Results are logged with counts per event type
 - On first run for a repo, looks back 30 days; subsequent runs use KV cursor
-- Parallelizes API calls across resource types (PRs, issues, commits, comments, workflow runs)
+- Parallelizes API calls across resource types (PRs, issues, commits, comments, workflow runs, deployments, releases)

--- a/workers/connectors/github/src/normalize.ts
+++ b/workers/connectors/github/src/normalize.ts
@@ -26,6 +26,12 @@ export function normalizeGitHubEvent(
       return [normalizePush(payload, now)];
     case "workflow_run":
       return [normalizeWorkflowRun(payload, now)];
+    case "deployment":
+      return [normalizeDeployment(payload, now)];
+    case "deployment_status":
+      return [normalizeDeploymentStatus(payload, now)];
+    case "release":
+      return [normalizeRelease(payload, now)];
     default:
       return [normalizeGeneric(eventType, payload, now)];
   }
@@ -354,6 +360,147 @@ function normalizeWorkflowRun(
     payload,
     summary: parts.join(" | "),
     tags: conclusion === "failure" ? ["build-failure"] : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deployment
+// ---------------------------------------------------------------------------
+
+function normalizeDeployment(
+  payload: Record<string, unknown>,
+  now: string
+): OpenChiefEvent {
+  const action = payload.action as string;
+  const deployment = payload.deployment as Record<string, unknown>;
+  const repo = payload.repository as Record<string, unknown>;
+  const sender = payload.sender as Record<string, unknown>;
+
+  const environment = deployment.environment as string;
+  const ref = deployment.ref as string;
+  const description = deployment.description as string | null;
+  const createdAt = deployment.created_at as string;
+
+  const parts = [
+    `Deployment ${action} to "${environment}" in ${repo.full_name}`,
+    `ref=${ref}`,
+    `by=${sender.login}`,
+    `at=${createdAt}`,
+  ];
+  if (description) parts.push(`description="${description.slice(0, 100)}"`);
+
+  return {
+    id: generateULID(),
+    timestamp: createdAt || now,
+    ingestedAt: now,
+    source: "github",
+    eventType: `deploy.${action}`,
+    scope: {
+      org: (repo.owner as Record<string, unknown>)?.login as string,
+      project: repo.full_name as string,
+      actor: sender.login as string,
+    },
+    payload,
+    summary: parts.join(" | "),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deployment Status
+// ---------------------------------------------------------------------------
+
+function normalizeDeploymentStatus(
+  payload: Record<string, unknown>,
+  now: string
+): OpenChiefEvent {
+  const deploymentStatus = payload.deployment_status as Record<string, unknown>;
+  const deployment = payload.deployment as Record<string, unknown>;
+  const repo = payload.repository as Record<string, unknown>;
+  const sender = payload.sender as Record<string, unknown>;
+
+  const state = deploymentStatus.state as string; // success, failure, error, pending, in_progress
+  const environment = deploymentStatus.environment as string;
+  const description = deploymentStatus.description as string | null;
+  const createdAt = deploymentStatus.created_at as string;
+  const ref = deployment.ref as string;
+
+  const eventType =
+    state === "success"
+      ? "deploy.succeeded"
+      : state === "failure" || state === "error"
+        ? "deploy.failed"
+        : `deploy.${state}`;
+
+  const parts = [
+    `Deploy to "${environment}" ${state} in ${repo.full_name}`,
+    `ref=${ref}`,
+    `by=${sender.login}`,
+    `at=${createdAt}`,
+  ];
+  if (description) parts.push(`description="${description.slice(0, 100)}"`);
+
+  return {
+    id: generateULID(),
+    timestamp: createdAt || now,
+    ingestedAt: now,
+    source: "github",
+    eventType,
+    scope: {
+      org: (repo.owner as Record<string, unknown>)?.login as string,
+      project: repo.full_name as string,
+      actor: sender.login as string,
+    },
+    payload,
+    summary: parts.join(" | "),
+    tags: state === "failure" || state === "error" ? ["deploy-failure"] : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Release
+// ---------------------------------------------------------------------------
+
+function normalizeRelease(
+  payload: Record<string, unknown>,
+  now: string
+): OpenChiefEvent {
+  const action = payload.action as string;
+  const release = payload.release as Record<string, unknown>;
+  const repo = payload.repository as Record<string, unknown>;
+  const sender = payload.sender as Record<string, unknown>;
+
+  const tagName = release.tag_name as string;
+  const name = release.name as string | null;
+  const draft = release.draft as boolean;
+  const prerelease = release.prerelease as boolean;
+  const createdAt = release.created_at as string;
+  const publishedAt = release.published_at as string | null;
+  const body = release.body as string | null;
+  const bodyPreview = body?.slice(0, 200) || "";
+
+  const parts = [
+    `Release "${name || tagName}" ${action} in ${repo.full_name}`,
+    `tag=${tagName}`,
+    `by=${sender.login}`,
+    `at=${publishedAt || createdAt}`,
+  ];
+  if (draft) parts.push("draft=true");
+  if (prerelease) parts.push("prerelease=true");
+  if (bodyPreview) parts.push(`notes="${bodyPreview.slice(0, 100)}"`);
+
+  return {
+    id: generateULID(),
+    timestamp: publishedAt || createdAt || now,
+    ingestedAt: now,
+    source: "github",
+    eventType: `release.${action}`,
+    scope: {
+      org: (repo.owner as Record<string, unknown>)?.login as string,
+      project: repo.full_name as string,
+      actor: sender.login as string,
+    },
+    payload,
+    summary: parts.join(" | "),
   };
 }
 

--- a/workers/connectors/github/src/poll.ts
+++ b/workers/connectors/github/src/poll.ts
@@ -33,6 +33,8 @@ interface PollResult {
   issues: number;
   pushes: number;
   workflows: number;
+  deployments: number;
+  releases: number;
   total: number;
 }
 
@@ -86,19 +88,24 @@ async function pollRepo(repo: string, env: PollEnv): Promise<PollResult> {
       return [] as unknown as T;
     });
 
-  const [reviews, issues, commits, comments, workflows] = await Promise.all([
-    safeFetch(fetchReviews(repo, rawPRs, token), "reviews"),
-    safeFetch(fetchIssues(repo, since, token), "issues"),
-    safeFetch(fetchCommits(repo, since, token), "commits"),
-    safeFetch(fetchComments(repo, since, token), "comments"),
-    safeFetch(fetchWorkflowRuns(repo, since, token), "workflows"),
-  ]);
+  const [reviews, issues, commits, comments, workflows, deployments, releases] =
+    await Promise.all([
+      safeFetch(fetchReviews(repo, rawPRs, token), "reviews"),
+      safeFetch(fetchIssues(repo, since, token), "issues"),
+      safeFetch(fetchCommits(repo, since, token), "commits"),
+      safeFetch(fetchComments(repo, since, token), "comments"),
+      safeFetch(fetchWorkflowRuns(repo, since, token), "workflows"),
+      safeFetch(fetchDeployments(repo, since, token), "deployments"),
+      safeFetch(fetchReleases(repo, since, token), "releases"),
+    ]);
 
   events.push(...reviews);
   events.push(...issues);
   events.push(...commits);
   events.push(...comments);
   events.push(...workflows);
+  events.push(...deployments);
+  events.push(...releases);
 
   // Enqueue all events
   let queued = 0;
@@ -112,7 +119,7 @@ async function pollRepo(repo: string, env: PollEnv): Promise<PollResult> {
   await env.POLL_CURSOR.put(cursorKey, now);
 
   console.log(
-    `Polled ${repo}: ${queued} events enqueued (${prEvents.length} PRs, ${reviews.length} reviews, ${comments.length} comments, ${issues.length} issues, ${commits.length} commits, ${workflows.length} workflows)`
+    `Polled ${repo}: ${queued} events enqueued (${prEvents.length} PRs, ${reviews.length} reviews, ${comments.length} comments, ${issues.length} issues, ${commits.length} commits, ${workflows.length} workflows, ${deployments.length} deployments, ${releases.length} releases)`
   );
 
   return {
@@ -123,6 +130,8 @@ async function pollRepo(repo: string, env: PollEnv): Promise<PollResult> {
     issues: issues.length,
     pushes: commits.length,
     workflows: workflows.length,
+    deployments: deployments.length,
+    releases: releases.length,
     total: queued,
   };
 }
@@ -180,6 +189,18 @@ function slimPayload(event: OpenChiefEvent): OpenChiefEvent {
   // Workflow data
   if (p.triggering_actor) slim.triggering_actor = p.triggering_actor;
   if (p.head_branch) slim.head_branch = p.head_branch;
+
+  // Deployment data
+  if (p.environment) slim.environment = p.environment;
+  if (p.ref) slim.ref = p.ref;
+  if (p.description) slim.description = p.description;
+  if (p.deployment_url) slim.deployment_url = p.deployment_url;
+  if (p.target_url) slim.target_url = p.target_url;
+
+  // Release data
+  if (p.tag_name) slim.tag_name = p.tag_name;
+  if (p.prerelease !== undefined) slim.prerelease = p.prerelease;
+  if (p.body_preview) slim.body_preview = p.body_preview;
 
   return { ...event, payload: slim };
 }
@@ -623,6 +644,171 @@ async function fetchCommits(
       summary: `${login} committed "${message}" in ${repo}`,
     };
   });
+}
+
+/**
+ * Fetch recent deployments and their latest statuses.
+ * Gives us: deploy frequency, environments, success/failure rates.
+ */
+async function fetchDeployments(
+  repo: string,
+  since: string,
+  token: string
+): Promise<OpenChiefEvent[]> {
+  const [owner] = repo.split("/");
+  const url = `https://api.github.com/repos/${repo}/deployments?per_page=100`;
+  const deployments = await githubPaginate<Record<string, unknown>>(
+    url,
+    token,
+    3
+  );
+  const now = new Date().toISOString();
+  const events: OpenChiefEvent[] = [];
+
+  const filtered = deployments.filter(
+    (d) => (d.created_at as string) >= since
+  );
+
+  for (const dep of filtered) {
+    const creator = dep.creator as Record<string, unknown>;
+    const environment = dep.environment as string;
+    const ref = dep.ref as string;
+    const description = (dep.description as string) || "";
+    const createdAt = dep.created_at as string;
+
+    // Fetch the latest status for this deployment
+    let latestState = "pending";
+    let targetUrl: string | null = null;
+    try {
+      const statusUrl = `https://api.github.com/repos/${repo}/deployments/${dep.id}/statuses?per_page=1`;
+      const statuses = (await githubFetch(statusUrl, token)) as Array<
+        Record<string, unknown>
+      >;
+      if (statuses.length > 0) {
+        latestState = statuses[0].state as string;
+        targetUrl = (statuses[0].target_url as string) || null;
+      }
+    } catch {
+      // If we can't get statuses, still emit the deployment event
+    }
+
+    const eventType =
+      latestState === "success"
+        ? "deploy.succeeded"
+        : latestState === "failure" || latestState === "error"
+          ? "deploy.failed"
+          : `deploy.${latestState}`;
+
+    const parts = [
+      `Deployment to ${environment} ${latestState} in ${repo}`,
+      `ref=${ref}`,
+      `creator=${creator?.login}`,
+      `at=${createdAt}`,
+    ];
+    if (description) parts.push(`desc="${description.slice(0, 100)}"`);
+
+    events.push({
+      id: generateULID(),
+      timestamp: createdAt,
+      ingestedAt: now,
+      source: "github",
+      eventType,
+      scope: {
+        org: owner,
+        project: repo,
+        actor: creator?.login as string,
+      },
+      payload: {
+        environment,
+        ref,
+        description: description.slice(0, 200),
+        status: latestState,
+        html_url: dep.url,
+        target_url: targetUrl,
+        created_at: createdAt,
+      },
+      summary: parts.join(" | "),
+      tags:
+        latestState === "failure" || latestState === "error"
+          ? ["deploy-failure"]
+          : undefined,
+    });
+  }
+
+  return events;
+}
+
+/**
+ * Fetch recent releases (tags, changelogs, assets).
+ * Gives us: release cadence, versioning patterns, changelog quality.
+ */
+async function fetchReleases(
+  repo: string,
+  since: string,
+  token: string
+): Promise<OpenChiefEvent[]> {
+  const [owner] = repo.split("/");
+  const url = `https://api.github.com/repos/${repo}/releases?per_page=100`;
+  const releases = await githubPaginate<Record<string, unknown>>(
+    url,
+    token,
+    3
+  );
+  const now = new Date().toISOString();
+
+  return releases
+    .filter((r) => (r.created_at as string) >= since)
+    .map((release) => {
+      const author = release.author as Record<string, unknown>;
+      const tagName = release.tag_name as string;
+      const name = (release.name as string) || tagName;
+      const body = (release.body as string) || "";
+      const isDraft = release.draft as boolean;
+      const isPrerelease = release.prerelease as boolean;
+      const createdAt = release.created_at as string;
+
+      const flags = [
+        isDraft ? "draft" : null,
+        isPrerelease ? "prerelease" : null,
+      ]
+        .filter(Boolean)
+        .join(",");
+
+      const parts = [
+        `Release ${tagName} "${name}" by ${author?.login} in ${repo}`,
+        `at=${createdAt}`,
+      ];
+      if (flags) parts.push(`flags=[${flags}]`);
+      if (body) parts.push(`notes_preview="${body.slice(0, 100)}"`);
+
+      return {
+        id: generateULID(),
+        timestamp: createdAt,
+        ingestedAt: now,
+        source: "github",
+        eventType: isDraft
+          ? "release.created"
+          : isPrerelease
+            ? "release.prereleased"
+            : "release.published",
+        scope: {
+          org: owner,
+          project: repo,
+          actor: author?.login as string,
+        },
+        payload: {
+          tag_name: tagName,
+          name,
+          draft: isDraft,
+          prerelease: isPrerelease,
+          body_preview: body.slice(0, 200),
+          html_url: release.html_url,
+          created_at: createdAt,
+        },
+        summary: parts.join(" | "),
+        tags: isDraft ? ["draft"] : undefined,
+      };
+    });
 }
 
 async function fetchWorkflowRuns(

--- a/workers/dashboard/index.html
+++ b/workers/dashboard/index.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenChief</title>
+    <meta name="description" content="AI agents that passively watch your business tools and produce actionable reports." />
+    <meta name="theme-color" content="#0a0a0a" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="OpenChief" />
+    <meta property="og:description" content="AI agents that passively watch your business tools and produce actionable reports." />
+    <meta property="og:site_name" content="OpenChief" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="OpenChief" />
+    <meta name="twitter:description" content="AI agents that passively watch your business tools and produce actionable reports." />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/workers/dashboard/public/favicon.svg
+++ b/workers/dashboard/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#0a0a0a"/>
+  <g transform="translate(3, 4) scale(0.41)">
+    <path d="M10 44C10 44 18 50 32 50C46 50 54 44 54 44" stroke="#6195ED" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M10 44L14 22L24 36" stroke="#6195ED" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <path d="M54 44L50 22L40 36" stroke="#6195ED" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <path d="M24 36L32 16L40 36" stroke="#6195ED" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  </g>
+</svg>

--- a/workers/dashboard/src/components/ui/label.tsx
+++ b/workers/dashboard/src/components/ui/label.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { Label as LabelPrimitive } from "radix-ui";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+  React.ComponentRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/workers/dashboard/src/pages/ConnectionDetail.tsx
+++ b/workers/dashboard/src/pages/ConnectionDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import {
   ChevronRight,
@@ -6,11 +6,15 @@ import {
   Save,
   Eye,
   EyeOff,
-  Shield,
   Loader2,
   BookOpen,
   Terminal,
+  Settings,
+  Activity,
+  Users,
+  Zap,
 } from "lucide-react";
+import { BarChart, Bar, CartesianGrid, XAxis } from "recharts";
 import {
   api,
   type ConnectorConfigResponse,
@@ -20,14 +24,24 @@ import {
 import { formatDateTime, timeAgo } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
 import {
   Card,
   CardContent,
+  CardFooter,
   CardHeader,
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 import {
   Table,
   TableBody,
@@ -39,24 +53,210 @@ import {
 import { SourceIcon } from "@/components/SourceIcon";
 
 interface AgentAccess {
-  agentId: string;
-  agentName: string;
+  id: string;
+  name: string;
   tools: string[];
 }
 
+interface ConnectionStats {
+  volume: { date: string; count: number }[];
+  eventTypes: { eventType: string; count: number }[];
+  topActors: { actor: string; count: number }[];
+}
+
+const EVENT_TYPE_COLORS = [
+  "#34d399", "#fbbf24", "#818cf8", "#f87171",
+  "#38bdf8", "#fb923c", "#a78bfa", "#4ade80",
+  "#f472b6", "#94a3b8",
+];
+
 // ---------------------------------------------------------------------------
-// Setup Guide
+// Connection Charts
+// ---------------------------------------------------------------------------
+
+function EventVolumeChart({ data }: { data: ConnectionStats["volume"] }) {
+  const { chartData, totalEvents } = useMemo(() => {
+    const byDate: Record<string, number> = {};
+    let totalEvents = 0;
+    for (const row of data) {
+      byDate[row.date] = row.count;
+      totalEvents += row.count;
+    }
+    const chartData: { date: string; label: string; events: number }[] = [];
+    const now = new Date();
+    for (let i = 29; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      const key = d.toISOString().slice(0, 10);
+      const label = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+      chartData.push({ date: key, label, events: byDate[key] || 0 });
+    }
+    return { chartData, totalEvents };
+  }, [data]);
+
+  const chartConfig: ChartConfig = {
+    events: { label: "Events", color: "#34d399" },
+  };
+
+  return (
+    <Card className="flex flex-col gap-0 py-3">
+      <CardHeader className="pb-1">
+        <CardTitle className="text-sm">Event Volume</CardTitle>
+        <CardDescription className="text-xs">Last 30 days</CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 pb-0">
+        {totalEvents === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-6 text-muted-foreground/40">
+            <Activity className="h-8 w-8" />
+            <span className="text-xs font-medium">No events yet</span>
+          </div>
+        ) : (
+          <ChartContainer config={chartConfig} className="aspect-auto h-[120px] w-full">
+            <BarChart accessibilityLayer data={chartData} margin={{ left: 0, right: 4, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} />
+              <XAxis dataKey="label" tickLine={false} axisLine={false} tickMargin={8} tickFormatter={(v) => v.slice(0, 3)} tick={{ fontSize: 10 }} />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Bar dataKey="events" fill="#34d399" radius={[2, 2, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+      <CardFooter className="pt-1 pb-0 px-4">
+        <div className="text-xs text-muted-foreground leading-none">
+          {totalEvents > 0
+            ? `${totalEvents.toLocaleString()} events in the last 30 days`
+            : "Waiting for events"}
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function EventTypesChart({ data }: { data: ConnectionStats["eventTypes"] }) {
+  const { chartData, topType } = useMemo(() => {
+    const chartData = data.map((row, i) => ({
+      type: row.eventType,
+      count: row.count,
+      fill: EVENT_TYPE_COLORS[i % EVENT_TYPE_COLORS.length],
+    }));
+    const topType = data.length > 0 ? data[0].eventType : null;
+    return { chartData, topType };
+  }, [data]);
+
+  const chartConfig: ChartConfig = {};
+  for (const row of chartData) {
+    chartConfig[row.type] = { label: row.type, color: row.fill };
+  }
+
+  return (
+    <Card className="flex flex-col gap-0 py-3">
+      <CardHeader className="pb-1">
+        <CardTitle className="text-sm">Event Types</CardTitle>
+        <CardDescription className="text-xs">Top types by volume</CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 pb-0">
+        {data.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-6 text-muted-foreground/40">
+            <Zap className="h-8 w-8" />
+            <span className="text-xs font-medium">No events yet</span>
+          </div>
+        ) : (
+          <ChartContainer config={chartConfig} className="aspect-auto h-[120px] w-full">
+            <BarChart accessibilityLayer data={chartData} margin={{ left: 0, right: 4, top: 8, bottom: 0 }}>
+              <CartesianGrid vertical={false} />
+              <XAxis dataKey="type" tickLine={false} axisLine={false} tickMargin={4} tick={{ fontSize: 9 }} interval={0} angle={-30} textAnchor="end" />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Bar dataKey="count" radius={[2, 2, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+      <CardFooter className="pt-1 pb-0 px-4">
+        <div className="text-xs text-muted-foreground leading-none">
+          {topType
+            ? `Most common: ${topType}`
+            : "Waiting for events"}
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function ConsumersCard({
+  agents,
+  events,
+}: {
+  agents: AgentAccess[];
+  events: ConnectionEvent[];
+}) {
+  const lastEvent = events.length > 0 ? events[0] : null;
+  const uniqueActors = useMemo(() => {
+    const actors = new Set<string>();
+    for (const e of events) {
+      if (e.actor) actors.add(e.actor);
+    }
+    return actors.size;
+  }, [events]);
+
+  return (
+    <Card className="flex flex-col gap-0 py-3">
+      <CardHeader className="pb-1">
+        <CardTitle className="text-sm">Connection Info</CardTitle>
+        <CardDescription className="text-xs">Agents &amp; activity</CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 pb-0">
+        <div className="space-y-3 py-1">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Subscribing agents</span>
+            <span className="text-sm font-medium">{agents.length}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Unique actors</span>
+            <span className="text-sm font-medium">{uniqueActors}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Ingestion</span>
+            <Badge variant="outline" className="text-xs">Webhook + Poll</Badge>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Last event</span>
+            <span className="text-xs font-medium">
+              {lastEvent ? timeAgo(lastEvent.timestamp) : "—"}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="pt-1 pb-0 px-4">
+        <div className="flex flex-wrap gap-1">
+          {agents.slice(0, 5).map((a) => (
+            <Link key={a.id} to={`/modules/${a.id}`}>
+              <Badge variant="secondary" className="text-xs cursor-pointer hover:bg-accent">
+                {a.name}
+              </Badge>
+            </Link>
+          ))}
+          {agents.length > 5 && (
+            <Badge variant="secondary" className="text-xs">
+              +{agents.length - 5} more
+            </Badge>
+          )}
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup Guide Data
 // ---------------------------------------------------------------------------
 
 interface SetupGuideData {
-  title: string;
   manual: { step: string; detail: string }[];
   claudeCode?: string;
 }
 
 const SETUP_GUIDES: Record<string, SetupGuideData> = {
   github: {
-    title: "GitHub App Setup Guide",
     manual: [
       {
         step: "Create a GitHub App",
@@ -71,12 +271,12 @@ const SETUP_GUIDES: Record<string, SetupGuideData> = {
       {
         step: "Set repository permissions",
         detail:
-          "Under Repository permissions, set the following to Read-only: Commit statuses, Contents, Issues, Metadata (mandatory), Pull requests.",
+          "Under Repository permissions, set the following to Read-only: Actions, Commit statuses, Contents, Deployments, Issues, Metadata (mandatory), Pull requests.",
       },
       {
         step: "Subscribe to events",
         detail:
-          "Check these event subscriptions: Create, Delete, Issue comment, Issues, Pull request, Pull request review, Push, Status.",
+          "Check these event subscriptions: Create, Delete, Deployment, Deployment status, Issue comment, Issues, Pull request, Pull request review, Pull request review comment, Push, Release, Status, Workflow run.",
       },
       {
         step: 'Select "Only on this account" and create the app',
@@ -100,10 +300,9 @@ const SETUP_GUIDES: Record<string, SetupGuideData> = {
       },
     ],
     claudeCode:
-      'You can automate the GitHub App setup using Claude Code with browser automation. Use this prompt:\n\n"Create a new GitHub App for OpenChief on my organization. Navigate to GitHub → Organization Settings → Developer Settings → GitHub Apps → New. Fill in the app name, set the webhook URL to my GitHub connector worker URL, generate a webhook secret, set repository permissions (Commit statuses, Contents, Issues, Pull requests — all Read-only), subscribe to events (Create, Delete, Issue comment, Issues, Pull request, Pull request review, Push, Status), select Only on this account, create the app, generate a private key, install it on the org for all repos, then convert the private key to PKCS#8 and set all the wrangler secrets on the connector worker."',
+      'You can automate the GitHub App setup using Claude Code with browser automation. Use this prompt:\n\n"Create a new GitHub App for OpenChief on my organization. Navigate to GitHub → Organization Settings → Developer Settings → GitHub Apps → New. Fill in the app name, set the webhook URL to my GitHub connector worker URL, generate a webhook secret, set repository permissions (Actions, Commit statuses, Contents, Deployments, Issues, Pull requests — all Read-only), subscribe to events (Create, Delete, Deployment, Deployment status, Issue comment, Issues, Pull request, Pull request review, Pull request review comment, Push, Release, Status, Workflow run), select Only on this account, create the app, generate a private key, install it on the org for all repos, then convert the private key to PKCS#8 and set all the wrangler secrets on the connector worker."',
   },
   slack: {
-    title: "Slack App Setup Guide",
     manual: [
       {
         step: "Create a Slack App",
@@ -131,13 +330,105 @@ const SETUP_GUIDES: Record<string, SetupGuideData> = {
   },
 };
 
-function SetupGuide({ source }: { source: string }) {
-  const guide = SETUP_GUIDES[source];
-  const [expanded, setExpanded] = useState(false);
+// ---------------------------------------------------------------------------
+// Configuration (unified: setup guide + credentials)
+// ---------------------------------------------------------------------------
+
+function SetupGuideContent({ guide }: { guide: SetupGuideData }) {
   const [activeTab, setActiveTab] = useState<"manual" | "claude">(
-    guide?.claudeCode ? "claude" : "manual",
+    guide.claudeCode ? "claude" : "manual",
   );
-  if (!guide) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <BookOpen className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Setup Guide</span>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 rounded-lg bg-muted p-1">
+        <button
+          onClick={() => setActiveTab("manual")}
+          className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+            activeTab === "manual"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <BookOpen className="h-3 w-3" />
+          Manual Setup
+        </button>
+        {guide.claudeCode && (
+          <button
+            onClick={() => setActiveTab("claude")}
+            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              activeTab === "claude"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Terminal className="h-3 w-3" />
+            Claude Code
+          </button>
+        )}
+      </div>
+
+      {activeTab === "manual" ? (
+        <ol className="space-y-3">
+          {guide.manual.map((item, i) => (
+            <li key={i} className="flex gap-3">
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+                {i + 1}
+              </span>
+              <div>
+                <p className="text-sm font-medium">{item.step}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
+                  {item.detail}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            If you have Claude Code with browser automation (MCP Chrome
+            extension), you can automate the entire setup. Copy the prompt below
+            and paste it into Claude Code:
+          </p>
+          <pre className="whitespace-pre-wrap rounded-lg bg-muted p-4 text-xs leading-relaxed">
+            {guide.claudeCode}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConfigurationSection({
+  source,
+  config,
+  fieldValues,
+  revealedFields,
+  hasChanges,
+  saving,
+  onFieldChange,
+  onToggleReveal,
+  onSave,
+}: {
+  source: string;
+  config: ConnectorConfigResponse;
+  fieldValues: Record<string, string>;
+  revealedFields: Set<string>;
+  hasChanges: boolean;
+  saving: boolean;
+  onFieldChange: (key: string, value: string) => void;
+  onToggleReveal: (key: string) => void;
+  onSave: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const guide = SETUP_GUIDES[source] ?? null;
 
   return (
     <Card>
@@ -146,71 +437,58 @@ function SetupGuide({ source }: { source: string }) {
         className="flex w-full items-center justify-between px-6 py-4 text-left"
       >
         <div className="flex items-center gap-2">
-          <BookOpen className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium">{guide.title}</span>
+          <Settings className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium">Configuration</span>
+          <span className="text-xs text-muted-foreground">
+            {guide ? "Setup guide, credentials & settings" : "Manage connection credentials and settings"}
+          </span>
         </div>
         <ChevronDown
           className={`h-4 w-4 text-muted-foreground transition-transform ${expanded ? "rotate-180" : ""}`}
         />
       </button>
       {expanded && (
-        <CardContent className="pt-0">
-          {/* Tabs */}
-          <div className="mb-4 flex gap-1 rounded-lg bg-muted p-1">
-            <button
-              onClick={() => setActiveTab("manual")}
-              className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                activeTab === "manual"
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              <BookOpen className="h-3 w-3" />
-              Manual Setup
-            </button>
-            {guide.claudeCode && (
-              <button
-                onClick={() => setActiveTab("claude")}
-                className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                  activeTab === "claude"
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                <Terminal className="h-3 w-3" />
-                Claude Code
-              </button>
-            )}
-          </div>
-
-          {activeTab === "manual" ? (
-            <ol className="space-y-3">
-              {guide.manual.map((item, i) => (
-                <li key={i} className="flex gap-3">
-                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
-                    {i + 1}
-                  </span>
-                  <div>
-                    <p className="text-sm font-medium">{item.step}</p>
-                    <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-                      {item.detail}
-                    </p>
-                  </div>
-                </li>
-              ))}
-            </ol>
-          ) : (
-            <div className="space-y-3">
-              <p className="text-sm text-muted-foreground">
-                If you have Claude Code with browser automation (MCP Chrome
-                extension), you can automate the entire setup. Copy the prompt
-                below and paste it into Claude Code:
-              </p>
-              <pre className="whitespace-pre-wrap rounded-lg bg-muted p-4 text-xs leading-relaxed">
-                {guide.claudeCode}
-              </pre>
-            </div>
+        <CardContent className="space-y-6 pt-0">
+          {/* Setup Guide (if available for this source) */}
+          {guide && (
+            <>
+              <SetupGuideContent guide={guide} />
+              <Separator />
+            </>
           )}
+
+          {/* Credential Fields */}
+          <div className="space-y-4">
+            {config.fields.map((field) => (
+              <FieldRow
+                key={field.key}
+                field={field}
+                value={fieldValues[field.key] ?? ""}
+                revealed={revealedFields.has(field.key)}
+                onValueChange={(v) => onFieldChange(field.key, v)}
+                onToggleReveal={() => onToggleReveal(field.key)}
+              />
+            ))}
+            <div className="flex justify-end pt-2">
+              <Button
+                onClick={onSave}
+                disabled={!hasChanges || saving}
+                size="sm"
+              >
+                {saving ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="mr-1.5 h-3.5 w-3.5" />
+                    Save Settings
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
         </CardContent>
       )}
     </Card>
@@ -226,6 +504,7 @@ export function ConnectionDetail() {
   const [config, setConfig] = useState<ConnectorConfigResponse | null>(null);
   const [events, setEvents] = useState<ConnectionEvent[]>([]);
   const [agentAccess, setAgentAccess] = useState<AgentAccess[]>([]);
+  const [stats, setStats] = useState<ConnectionStats | null>(null);
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [revealedFields, setRevealedFields] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
@@ -234,7 +513,7 @@ export function ConnectionDetail() {
   const loadData = useCallback(async () => {
     if (!source) return;
     try {
-      const [configData, eventData, accessData] = await Promise.all([
+      const [configData, eventData, accessData, statsData] = await Promise.all([
         api
           .get<ConnectorConfigResponse>(`connections/${source}/settings`)
           .catch(() => null),
@@ -242,11 +521,16 @@ export function ConnectionDetail() {
           .get<ConnectionEvent[]>(`connections/${source}/events?limit=100`)
           .catch(() => []),
         api
-          .get<AgentAccess[]>(`connections/${source}/access`)
+          .get<{ agents: AgentAccess[] }>(`connections/${source}/access`)
+          .then((d) => d?.agents ?? [])
           .catch(() => []),
+        api
+          .get<ConnectionStats>(`connections/${source}/stats`)
+          .catch(() => null),
       ]);
       setConfig(configData);
       setEvents(eventData);
+      setStats(statsData);
       setAgentAccess(accessData);
     } catch (err) {
       console.error("Failed to load connection:", err);
@@ -327,91 +611,28 @@ export function ConnectionDetail() {
         </div>
       </div>
 
-      {/* Setup Guide */}
-      {source && SETUP_GUIDES[source] && (
-        <SetupGuide source={source} />
+      {/* Charts */}
+      {stats && events.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <EventVolumeChart data={stats.volume} />
+          <EventTypesChart data={stats.eventTypes} />
+          <ConsumersCard agents={agentAccess} events={events} />
+        </div>
       )}
 
-      {/* Configuration */}
-      {config && config.fields.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Configuration</CardTitle>
-            <CardDescription>
-              Manage connection credentials and settings
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {config.fields.map((field) => (
-              <FieldRow
-                key={field.key}
-                field={field}
-                value={fieldValues[field.key] ?? ""}
-                revealed={revealedFields.has(field.key)}
-                onValueChange={(v) => handleFieldChange(field.key, v)}
-                onToggleReveal={() => toggleReveal(field.key)}
-              />
-            ))}
-            <div className="flex justify-end pt-2">
-              <Button
-                onClick={handleSave}
-                disabled={!hasChanges || saving}
-                size="sm"
-              >
-                {saving ? (
-                  <>
-                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="mr-1.5 h-3.5 w-3.5" />
-                    Save Settings
-                  </>
-                )}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Agent Access */}
-      {agentAccess.length > 0 && (
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Shield className="h-4 w-4 text-muted-foreground" />
-              <CardTitle className="text-base">Agent Access</CardTitle>
-            </div>
-            <CardDescription>
-              Agents with tool-based access to this connection
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {agentAccess.map((access) => (
-                <div
-                  key={access.agentId}
-                  className="flex items-center justify-between rounded-md border px-3 py-2"
-                >
-                  <Link
-                    to={`/modules/${access.agentId}`}
-                    className="font-medium text-sm hover:underline"
-                  >
-                    {access.agentName}
-                  </Link>
-                  <div className="flex gap-1">
-                    {access.tools.map((tool) => (
-                      <Badge key={tool} variant="secondary" className="text-xs">
-                        {tool}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+      {/* Configuration (setup guide + credentials) */}
+      {config && config.fields.length > 0 && source && (
+        <ConfigurationSection
+          source={source}
+          config={config}
+          fieldValues={fieldValues}
+          revealedFields={revealedFields}
+          hasChanges={hasChanges}
+          saving={saving}
+          onFieldChange={handleFieldChange}
+          onToggleReveal={toggleReveal}
+          onSave={handleSave}
+        />
       )}
 
       {/* Recent Events */}
@@ -489,16 +710,17 @@ function FieldRow({
   onToggleReveal: () => void;
 }) {
   const showMasked = field.secret && field.configured && !value && !revealed;
+  const isMultiline = field.key.includes("private_key") || field.key.includes("pem");
 
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-2">
-        <label className="text-sm font-medium">
+        <Label htmlFor={field.key}>
           {field.label}
           {field.required && (
             <span className="ml-0.5 text-destructive">*</span>
           )}
-        </label>
+        </Label>
         {field.configured && (
           <Badge variant="secondary" className="text-xs">
             Configured
@@ -509,14 +731,26 @@ function FieldRow({
         <p className="text-xs text-muted-foreground">{field.description}</p>
       )}
       <div className="flex gap-2">
-        <Input
-          type={field.secret && !revealed ? "password" : "text"}
-          value={showMasked ? (field.maskedValue ?? "") : value}
-          onChange={(e) => onValueChange(e.target.value)}
-          placeholder={field.placeholder ?? undefined}
-          disabled={showMasked}
-          className="font-mono text-sm"
-        />
+        {isMultiline && !showMasked ? (
+          <Textarea
+            id={field.key}
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+            placeholder={field.placeholder ?? undefined}
+            className="min-h-[80px] font-mono text-sm"
+            rows={4}
+          />
+        ) : (
+          <Input
+            id={field.key}
+            type={field.secret && !revealed ? "password" : "text"}
+            value={showMasked ? (field.maskedValue ?? "") : value}
+            onChange={(e) => onValueChange(e.target.value)}
+            placeholder={field.placeholder ?? undefined}
+            disabled={showMasked}
+            className="font-mono text-sm"
+          />
+        )}
         {field.secret && (
           <Button
             variant="outline"

--- a/workers/dashboard/worker/index.ts
+++ b/workers/dashboard/worker/index.ts
@@ -665,6 +665,13 @@ export default {
         return handleGetConnectionEvents(env, source);
       }
 
+      // /api/connections/:source/stats
+      const connStatsMatch = path.match(/^\/api\/connections\/([^/]+)\/stats$/);
+      if (connStatsMatch && method === "GET") {
+        const source = decodeURIComponent(connStatsMatch[1]);
+        return handleGetConnectionStats(env, source);
+      }
+
       // /api/connections/:source/access
       const connAccessMatch = path.match(/^\/api\/connections\/([^/]+)\/access$/);
       if (connAccessMatch && method === "GET") {
@@ -1698,6 +1705,63 @@ async function handleGetConnectionEvents(
   }));
 
   return json(events);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/connections/:source/stats
+// ---------------------------------------------------------------------------
+async function handleGetConnectionStats(
+  env: Env,
+  source: string
+): Promise<Response> {
+  if (!CONNECTOR_CONFIGS[source]) return errorJson("Unknown connector", 404);
+
+  // Run all three queries in parallel
+  const [volumeResult, typesResult, actorsResult] = await Promise.all([
+    // Daily event volume for last 30 days
+    env.DB.prepare(
+      `SELECT DATE(timestamp) as date, COUNT(*) as count
+       FROM events
+       WHERE source = ? AND timestamp >= datetime('now', '-30 days')
+       GROUP BY DATE(timestamp)
+       ORDER BY date ASC`
+    )
+      .bind(source)
+      .all<{ date: string; count: number }>(),
+
+    // Event type breakdown (top 10)
+    env.DB.prepare(
+      `SELECT event_type, COUNT(*) as count
+       FROM events
+       WHERE source = ? AND timestamp >= datetime('now', '-30 days')
+       GROUP BY event_type
+       ORDER BY count DESC
+       LIMIT 10`
+    )
+      .bind(source)
+      .all<{ event_type: string; count: number }>(),
+
+    // Top actors (top 8)
+    env.DB.prepare(
+      `SELECT scope_actor as actor, COUNT(*) as count
+       FROM events
+       WHERE source = ? AND scope_actor IS NOT NULL AND timestamp >= datetime('now', '-30 days')
+       GROUP BY scope_actor
+       ORDER BY count DESC
+       LIMIT 8`
+    )
+      .bind(source)
+      .all<{ actor: string; count: number }>(),
+  ]);
+
+  return json({
+    volume: volumeResult.results || [],
+    eventTypes: (typesResult.results || []).map((r) => ({
+      eventType: r.event_type,
+      count: r.count,
+    })),
+    topActors: actorsResult.results || [],
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **GitHub deploy/release support** — Adds webhook normalizers for `deployment`, `deployment_status`, and `release` events. Adds `fetchDeployments()` and `fetchReleases()` to the GitHub polling pipeline, running in parallel with existing fetches. Produces `deploy.succeeded`/`deploy.failed`/`deploy.{state}` and `release.published`/`release.prereleased`/`release.created` event types.
- **Agent subscription updates** — Fixes dead subscription patterns (`push.*`, `review.*`, `comment.*` → `commit.*` + covered by `pr.*`/`issue.*`). Adds `deploy.*` and `release.*` to CISO, Engineering Manager, Product Manager, and Design Manager agents. Design Manager now subscribes to `release.*`/`deploy.*` instead of individual PR events.
- **Connection detail charts** — Adds three chart cards to connection pages: Event Volume (30-day bar chart), Event Types (vertical bar chart, top 10), and Connection Info (subscribing agents, unique actors, ingestion type, last event). New `GET /api/connections/:source/stats` API endpoint with 3 parallel D1 queries.
- **Unified configuration accordion** — Merges the setup guide and credential fields into a single collapsible Configuration card with a shadcn Separator between sections.
- **shadcn component upgrades** — Adds Label and Textarea components. Uses `Label` with proper `htmlFor`/`id` linkage, `Textarea` for multiline fields (private keys), `Separator` between setup guide and credentials.
- **Favicon & OG tags** — Adds SVG favicon using the OpenChief crown logo, Open Graph meta tags, Twitter Card tags, meta description, and theme-color.
- **Setup guide UI** — Collapsible setup guide with tabbed interface (Claude Code / Manual Setup) for GitHub and Slack connectors. Updated GitHub guide with correct permissions (Actions, Deployments) and all webhook event subscriptions.
- **Resilient GitHub polling** — `safeFetch()` wrapper prevents single endpoint failures from aborting the entire `Promise.all`.
- **Bug fixes** — Fixed AgentAccess API response shape mismatch (`.agents` extraction), removed standalone Agent Access card.

## Test plan
- [ ] `pnpm build` passes
- [ ] `pnpm typecheck` passes
- [ ] Dashboard `/connections/github` shows charts, configuration accordion with setup guide
- [ ] Event Types chart renders as vertical bars with X-axis labels
- [ ] Favicon visible in browser tab (crown logo)
- [ ] GitHub poll includes deployments and releases in output counts
- [ ] New webhook events (`deployment`, `deployment_status`, `release`) normalize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
