### PR TITLE
feat: configurable event types, instant task execution, improved Slack formatting

### DIFF
--- a/workers/connectors/jira/src/poll.ts
+++ b/workers/connectors/jira/src/poll.ts
@@ -17,6 +17,7 @@ export interface PollEnv {
   JIRA_API_EMAIL: string;
   JIRA_INSTANCE_URL: string;
   JIRA_PROJECTS?: string; // comma-separated project keys, e.g. "PROJ1,PROJ2"
+  JIRA_EVENT_TYPES?: string; // comma-separated: "issues,transitions,comments,sprints" (all if unset)
   POLL_CURSOR: KVNamespace;
 }
 
@@ -48,17 +49,25 @@ export async function runPoll(env: PollEnv): Promise<PollResult> {
 
   console.log(`Polling Jira since ${since}`);
 
+  // Parse enabled event types (default: all)
+  const enabledTypes = parseEventTypes(env.JIRA_EVENT_TYPES);
+
   const result: PollResult = { issues: 0, transitions: 0, comments: 0, sprints: 0, total: 0 };
 
   // 1. Poll recently updated issues (includes changelog for transitions)
-  const issueEvents = await pollIssues(client, env, since);
-  result.issues = issueEvents.issueCount;
-  result.transitions = issueEvents.transitionCount;
-  result.comments = issueEvents.commentCount;
+  // Skip entirely only if issues, transitions, AND comments are all disabled
+  if (enabledTypes.has("issues") || enabledTypes.has("transitions") || enabledTypes.has("comments")) {
+    const issueEvents = await pollIssues(client, env, since, enabledTypes);
+    result.issues = issueEvents.issueCount;
+    result.transitions = issueEvents.transitionCount;
+    result.comments = issueEvents.commentCount;
+  }
 
   // 2. Poll sprint changes
-  const sprintCount = await pollSprints(client, env, since);
-  result.sprints = sprintCount;
+  if (enabledTypes.has("sprints")) {
+    const sprintCount = await pollSprints(client, env, since);
+    result.sprints = sprintCount;
+  }
 
   result.total = result.issues + result.transitions + result.comments + result.sprints;
 
@@ -79,12 +88,17 @@ export async function runPoll(env: PollEnv): Promise<PollResult> {
 async function pollIssues(
   client: JiraClient,
   env: PollEnv,
-  since: string
+  since: string,
+  enabledTypes: Set<string>
 ): Promise<{ issueCount: number; transitionCount: number; commentCount: number }> {
   const { normalizeIssue, normalizeTransitions, normalizeComments } = await import("./normalize");
 
-  // Build JQL: updated since last poll, optionally filtered by projects
-  const sinceDate = since.slice(0, 16).replace("T", " "); // "2026-02-18 12:00"
+  // Build JQL: updated since last poll, optionally filtered by projects.
+  // Subtract a generous overlap because Jira JQL interprets dates in the
+  // authenticated user's timezone, but our cursor is stored as UTC.
+  // The router's INSERT OR IGNORE deduplicates any overlapping events.
+  const sinceMs = new Date(since).getTime() - 12 * 60 * 60 * 1000; // 12h overlap
+  const sinceDate = new Date(sinceMs).toISOString().slice(0, 16).replace("T", " ");
   const projects = parseProjects(env.JIRA_PROJECTS);
   let jql = `updated >= "${sinceDate}"`;
   if (projects.length > 0) {
@@ -103,22 +117,28 @@ async function pollIssues(
 
     for (const issue of result.issues) {
       // Emit issue created/updated event
-      const issueEvent = normalizeIssue(issue, since);
-      await env.EVENTS_QUEUE.send(issueEvent);
-      issueCount++;
+      if (enabledTypes.has("issues")) {
+        const issueEvent = normalizeIssue(issue, since);
+        await env.EVENTS_QUEUE.send(issueEvent);
+        issueCount++;
+      }
 
       // Emit transition events from changelog
-      const transitions = normalizeTransitions(issue, since);
-      for (const t of transitions) {
-        await env.EVENTS_QUEUE.send(t);
-        transitionCount++;
+      if (enabledTypes.has("transitions")) {
+        const transitions = normalizeTransitions(issue, since);
+        for (const t of transitions) {
+          await env.EVENTS_QUEUE.send(t);
+          transitionCount++;
+        }
       }
 
       // Emit comment events
-      const comments = normalizeComments(issue, since);
-      for (const c of comments) {
-        await env.EVENTS_QUEUE.send(c);
-        commentCount++;
+      if (enabledTypes.has("comments")) {
+        const comments = normalizeComments(issue, since);
+        for (const c of comments) {
+          await env.EVENTS_QUEUE.send(c);
+          commentCount++;
+        }
       }
     }
 
@@ -220,7 +240,8 @@ export async function runBackfill(
   console.log(`Backfilling Jira for ${days} days (since ${since})`);
 
   const result: PollResult = { issues: 0, transitions: 0, comments: 0, sprints: 0, total: 0 };
-  const issueEvents = await pollIssues(client, env, since);
+  const enabledTypes = parseEventTypes(env.JIRA_EVENT_TYPES);
+  const issueEvents = await pollIssues(client, env, since, enabledTypes);
   result.issues = issueEvents.issueCount;
   result.transitions = issueEvents.transitionCount;
   result.comments = issueEvents.commentCount;
@@ -233,6 +254,16 @@ export async function runBackfill(
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
+
+const ALL_EVENT_TYPES = new Set(["issues", "transitions", "comments", "sprints"]);
+
+function parseEventTypes(typesStr?: string): Set<string> {
+  if (!typesStr) return ALL_EVENT_TYPES;
+  const parsed = new Set(
+    typesStr.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean)
+  );
+  return parsed.size > 0 ? parsed : ALL_EVENT_TYPES;
+}
 
 function parseProjects(projectsStr?: string): string[] {
   if (!projectsStr) return [];

--- a/workers/connectors/jpd/src/poll.ts
+++ b/workers/connectors/jpd/src/poll.ts
@@ -14,6 +14,7 @@ export interface PollEnv {
   JPD_API_EMAIL: string;
   JPD_INSTANCE_URL: string;
   JPD_PROJECTS?: string; // comma-separated project keys
+  JPD_EVENT_TYPES?: string; // comma-separated: "ideas,changes,comments" (all if unset)
   POLL_CURSOR: KVNamespace;
 }
 
@@ -40,7 +41,8 @@ export async function runPoll(env: PollEnv): Promise<PollResult> {
 
   console.log(`Polling JPD since ${since}`);
 
-  const result = await pollIdeas(client, env, since);
+  const enabledTypes = parseEventTypes(env.JPD_EVENT_TYPES);
+  const result = await pollIdeas(client, env, since, enabledTypes);
 
   // Update cursor
   await env.POLL_CURSOR.put(CURSOR_KEY, now);
@@ -56,13 +58,16 @@ export async function runPoll(env: PollEnv): Promise<PollResult> {
 async function pollIdeas(
   client: JpdClient,
   env: PollEnv,
-  since: string
+  since: string,
+  enabledTypes: Set<string>,
 ): Promise<PollResult> {
   const { normalizeIdea, normalizeIdeaChanges, normalizeIdeaComments } = await import("./normalize");
 
-  // Build JQL to find JPD ideas updated since last poll
-  // JPD issues have issuetype "Idea" — filter to that
-  const sinceDate = since.slice(0, 16).replace("T", " ");
+  // Build JQL to find JPD ideas updated since last poll.
+  // Subtract 12h overlap because Jira JQL interprets dates in the user's
+  // timezone, but our cursor is stored as UTC. Router deduplicates via ULID.
+  const sinceMs = new Date(since).getTime() - 12 * 60 * 60 * 1000;
+  const sinceDate = new Date(sinceMs).toISOString().slice(0, 16).replace("T", " ");
   const projects = parseProjects(env.JPD_PROJECTS);
 
   let jql = `issuetype = Idea AND updated >= "${sinceDate}"`;
@@ -82,22 +87,28 @@ async function pollIdeas(
 
     for (const idea of result.issues) {
       // Emit idea created/updated event
-      const ideaEvent = normalizeIdea(idea, since);
-      await env.EVENTS_QUEUE.send(ideaEvent);
-      ideaCount++;
+      if (enabledTypes.has("ideas")) {
+        const ideaEvent = normalizeIdea(idea, since);
+        await env.EVENTS_QUEUE.send(ideaEvent);
+        ideaCount++;
+      }
 
       // Emit status and field change events from changelog
-      const changes = normalizeIdeaChanges(idea, since);
-      for (const c of changes) {
-        await env.EVENTS_QUEUE.send(c);
-        statusChangeCount++;
+      if (enabledTypes.has("changes")) {
+        const changes = normalizeIdeaChanges(idea, since);
+        for (const c of changes) {
+          await env.EVENTS_QUEUE.send(c);
+          statusChangeCount++;
+        }
       }
 
       // Emit comment events
-      const comments = normalizeIdeaComments(idea, since);
-      for (const c of comments) {
-        await env.EVENTS_QUEUE.send(c);
-        commentCount++;
+      if (enabledTypes.has("comments")) {
+        const comments = normalizeIdeaComments(idea, since);
+        for (const c of comments) {
+          await env.EVENTS_QUEUE.send(c);
+          commentCount++;
+        }
       }
     }
 
@@ -127,10 +138,21 @@ export async function runBackfill(
   );
 
   console.log(`Backfilling JPD for ${days} days (since ${since})`);
-  const result = await pollIdeas(client, env, since);
+  const enabledTypes = parseEventTypes(env.JPD_EVENT_TYPES);
+  const result = await pollIdeas(client, env, since, enabledTypes);
 
   await env.POLL_CURSOR.put(CURSOR_KEY, new Date().toISOString());
   return result;
+}
+
+const ALL_EVENT_TYPES = new Set(["ideas", "changes", "comments"]);
+
+function parseEventTypes(typesStr?: string): Set<string> {
+  if (!typesStr) return ALL_EVENT_TYPES;
+  const parsed = new Set(
+    typesStr.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean)
+  );
+  return parsed.size > 0 ? parsed : ALL_EVENT_TYPES;
 }
 
 function parseProjects(projectsStr?: string): string[] {

--- a/workers/connectors/jsm/src/poll.ts
+++ b/workers/connectors/jsm/src/poll.ts
@@ -18,6 +18,7 @@ export interface PollEnv {
   JSM_API_EMAIL: string;
   JSM_INSTANCE_URL: string;
   JSM_PROJECTS?: string; // comma-separated project keys
+  JSM_EVENT_TYPES?: string; // comma-separated: "requests,transitions,comments,sla,csat" (all if unset)
   POLL_CURSOR: KVNamespace;
 }
 
@@ -48,7 +49,8 @@ export async function runPoll(env: PollEnv): Promise<PollResult> {
 
   console.log(`Polling JSM since ${since}`);
 
-  const result = await pollRequests(client, env, since);
+  const enabledTypes = parseEventTypes(env.JSM_EVENT_TYPES);
+  const result = await pollRequests(client, env, since, enabledTypes);
 
   // Update cursor
   await env.POLL_CURSOR.put(CURSOR_KEY, now);
@@ -68,6 +70,7 @@ async function pollRequests(
   client: JsmClient,
   env: PollEnv,
   since: string,
+  enabledTypes: Set<string>,
 ): Promise<PollResult> {
   const {
     normalizeRequest,
@@ -77,8 +80,11 @@ async function pollRequests(
     normalizeCSAT,
   } = await import("./normalize");
 
-  // Build JQL: service desk issue types updated since last poll
-  const sinceDate = since.slice(0, 16).replace("T", " ");
+  // Build JQL: service desk issue types updated since last poll.
+  // Subtract 12h overlap because Jira JQL interprets dates in the user's
+  // timezone, but our cursor is stored as UTC. Router deduplicates via ULID.
+  const sinceMs = new Date(since).getTime() - 12 * 60 * 60 * 1000;
+  const sinceDate = new Date(sinceMs).toISOString().slice(0, 16).replace("T", " ");
   const projects = parseProjects(env.JSM_PROJECTS);
 
   // JSM request types typically include "Service Request", "[System] Service request",
@@ -98,33 +104,41 @@ async function pollRequests(
   const maxPages = 10;
 
   // Load known SLA breaches from KV to avoid re-emitting
-  const knownBreaches = await loadKnownBreaches(env.POLL_CURSOR);
+  const knownBreaches = enabledTypes.has("sla")
+    ? await loadKnownBreaches(env.POLL_CURSOR)
+    : new Set<string>();
 
   for (let page = 0; page < maxPages; page++) {
     const result = await client.searchRequests(jql, { startAt, maxResults: 50 });
 
     for (const request of result.issues) {
       // Emit request created/updated event
-      const requestEvent = normalizeRequest(request, since);
-      await env.EVENTS_QUEUE.send(requestEvent);
-      requestCount++;
+      if (enabledTypes.has("requests")) {
+        const requestEvent = normalizeRequest(request, since);
+        await env.EVENTS_QUEUE.send(requestEvent);
+        requestCount++;
+      }
 
       // Emit transition events from changelog
-      const transitions = normalizeTransitions(request, since);
-      for (const t of transitions) {
-        await env.EVENTS_QUEUE.send(t);
-        transitionCount++;
+      if (enabledTypes.has("transitions")) {
+        const transitions = normalizeTransitions(request, since);
+        for (const t of transitions) {
+          await env.EVENTS_QUEUE.send(t);
+          transitionCount++;
+        }
       }
 
       // Emit comment events
-      const comments = normalizeComments(request, since);
-      for (const c of comments) {
-        await env.EVENTS_QUEUE.send(c);
-        commentCount++;
+      if (enabledTypes.has("comments")) {
+        const comments = normalizeComments(request, since);
+        for (const c of comments) {
+          await env.EVENTS_QUEUE.send(c);
+          commentCount++;
+        }
       }
 
       // Check SLA breaches (rate-limited — only for active/open requests)
-      if (request.fields.status.statusCategory?.key !== "done") {
+      if (enabledTypes.has("sla") && request.fields.status.statusCategory?.key !== "done") {
         try {
           const slaRecords = await client.getRequestSLAs(request.key);
           const breachEvents = normalizeSLABreach(request, slaRecords, knownBreaches);
@@ -142,7 +156,7 @@ async function pollRequests(
       }
 
       // Check CSAT for resolved requests
-      if (request.fields.resolution) {
+      if (enabledTypes.has("csat") && request.fields.resolution) {
         try {
           const feedback = await client.getCSATFeedback(request.key);
           if (feedback) {
@@ -197,13 +211,24 @@ export async function runBackfill(
   );
 
   console.log(`Backfilling JSM for ${days} days (since ${since})`);
-  const result = await pollRequests(client, env, since);
+  const enabledTypes = parseEventTypes(env.JSM_EVENT_TYPES);
+  const result = await pollRequests(client, env, since, enabledTypes);
 
   await env.POLL_CURSOR.put(CURSOR_KEY, new Date().toISOString());
   return result;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const ALL_EVENT_TYPES = new Set(["requests", "transitions", "comments", "sla", "csat"]);
+
+function parseEventTypes(typesStr?: string): Set<string> {
+  if (!typesStr) return ALL_EVENT_TYPES;
+  const parsed = new Set(
+    typesStr.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean)
+  );
+  return parsed.size > 0 ? parsed : ALL_EVENT_TYPES;
+}
 
 function parseProjects(projectsStr?: string): string[] {
   if (!projectsStr) return [];

--- a/workers/connectors/slack/src/index.ts
+++ b/workers/connectors/slack/src/index.ts
@@ -376,6 +376,25 @@ async function handleInteractivePayload(
       });
 
       console.log(`Task ${taskId} approved by ${userName}`);
+
+      // Trigger instant task execution on the assigned agent
+      if (env.AGENT_RUNTIME && env.RUNTIME_ADMIN_SECRET) {
+        const taskRow = await env.DB.prepare(
+          "SELECT assigned_to FROM tasks WHERE id = ?"
+        ).bind(taskId).first<{ assigned_to: string | null }>();
+
+        if (taskRow?.assigned_to) {
+          env.AGENT_RUNTIME.fetch(
+            `https://runtime/trigger-task/${taskRow.assigned_to}`,
+            {
+              method: "POST",
+              headers: { Authorization: `Bearer ${env.RUNTIME_ADMIN_SECRET}` },
+            }
+          ).catch(err => {
+            console.error("Failed to trigger instant task execution:", err);
+          });
+        }
+      }
     } else if (actionId === "task_reject") {
       await env.DB.prepare(
         `UPDATE tasks SET status = 'cancelled', updated_at = ?

--- a/workers/dashboard/src/lib/api.ts
+++ b/workers/dashboard/src/lib/api.ts
@@ -75,6 +75,9 @@ export interface ConnectorConfigField {
   configured: boolean;
   maskedValue: string | null;
   updatedAt: string | null;
+  type?: "multiselect";
+  options?: Array<{ value: string; label: string }>;
+  category?: "credential" | "subscription";
 }
 
 export interface ConnectorConfigResponse {

--- a/workers/dashboard/src/pages/ConnectionDetail.tsx
+++ b/workers/dashboard/src/pages/ConnectionDetail.tsx
@@ -24,6 +24,7 @@ import {
   Trash2,
   ExternalLink,
   BarChart3,
+  SlidersHorizontal,
 } from "lucide-react";
 import { BarChart, Bar, CartesianGrid, XAxis } from "recharts";
 import {
@@ -710,6 +711,26 @@ function SetupGuideContent({ guide }: { guide: SetupGuideData }) {
   );
 }
 
+function SaveButton({ hasChanges, saving, onSave }: { hasChanges: boolean; saving: boolean; onSave: () => void }) {
+  return (
+    <div className="flex justify-end pt-2">
+      <Button onClick={onSave} disabled={!hasChanges || saving} size="sm">
+        {saving ? (
+          <>
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            Saving...
+          </>
+        ) : (
+          <>
+            <Save className="mr-1.5 h-3.5 w-3.5" />
+            Save Settings
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}
+
 function ConfigurationSection({
   source,
   config,
@@ -731,71 +752,89 @@ function ConfigurationSection({
   onToggleReveal: (key: string) => void;
   onSave: () => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [credExpanded, setCredExpanded] = useState(false);
+  const [subExpanded, setSubExpanded] = useState(false);
   const guide = SETUP_GUIDES[source] ?? null;
 
-  return (
-    <Card>
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center justify-between px-6 py-4 text-left"
-      >
-        <div className="flex items-center gap-2">
-          <Settings className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium">Configuration</span>
-          <span className="text-xs text-muted-foreground">
-            {guide ? "Setup guide, credentials & settings" : "Manage connection credentials and settings"}
-          </span>
-        </div>
-        <ChevronDown
-          className={`h-4 w-4 text-muted-foreground transition-transform ${expanded ? "rotate-180" : ""}`}
-        />
-      </button>
-      {expanded && (
-        <CardContent className="space-y-6 pt-0">
-          {/* Setup Guide (if available for this source) */}
-          {guide && (
-            <>
-              <SetupGuideContent guide={guide} />
-              <Separator />
-            </>
-          )}
+  const credentialFields = config.fields.filter((f) => f.category !== "subscription");
+  const subscriptionFields = config.fields.filter((f) => f.category === "subscription");
 
-          {/* Credential Fields */}
-          <div className="space-y-4">
-            {config.fields.map((field) => (
-              <FieldRow
-                key={field.key}
-                field={field}
-                value={fieldValues[field.key] ?? ""}
-                revealed={revealedFields.has(field.key)}
-                onValueChange={(v) => onFieldChange(field.key, v)}
-                onToggleReveal={() => onToggleReveal(field.key)}
-              />
-            ))}
-            <div className="flex justify-end pt-2">
-              <Button
-                onClick={onSave}
-                disabled={!hasChanges || saving}
-                size="sm"
-              >
-                {saving ? (
-                  <>
-                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="mr-1.5 h-3.5 w-3.5" />
-                    Save Settings
-                  </>
-                )}
-              </Button>
-            </div>
+  const renderFields = (fields: typeof config.fields) =>
+    fields.map((field) => (
+      <FieldRow
+        key={field.key}
+        field={field}
+        value={fieldValues[field.key] ?? ""}
+        revealed={revealedFields.has(field.key)}
+        onValueChange={(v) => onFieldChange(field.key, v)}
+        onToggleReveal={() => onToggleReveal(field.key)}
+      />
+    ));
+
+  return (
+    <>
+      {/* Connection Credentials */}
+      <Card>
+        <button
+          onClick={() => setCredExpanded(!credExpanded)}
+          className="flex w-full items-center justify-between px-6 py-4 text-left"
+        >
+          <div className="flex items-center gap-2">
+            <Settings className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">Connection</span>
+            <span className="text-xs text-muted-foreground">
+              {guide ? "Setup guide & credentials" : "Manage connection credentials"}
+            </span>
           </div>
-        </CardContent>
+          <ChevronDown
+            className={`h-4 w-4 text-muted-foreground transition-transform ${credExpanded ? "rotate-180" : ""}`}
+          />
+        </button>
+        {credExpanded && (
+          <CardContent className="space-y-6 pt-0">
+            {guide && (
+              <>
+                <SetupGuideContent guide={guide} />
+                <Separator />
+              </>
+            )}
+            <div className="space-y-4">
+              {renderFields(credentialFields)}
+              <SaveButton hasChanges={hasChanges} saving={saving} onSave={onSave} />
+            </div>
+          </CardContent>
+        )}
+      </Card>
+
+      {/* Subscription Settings (only if this connector has subscription fields) */}
+      {subscriptionFields.length > 0 && (
+        <Card>
+          <button
+            onClick={() => setSubExpanded(!subExpanded)}
+            className="flex w-full items-center justify-between px-6 py-4 text-left"
+          >
+            <div className="flex items-center gap-2">
+              <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm font-medium">Subscription</span>
+              <span className="text-xs text-muted-foreground">
+                Configure which data to ingest
+              </span>
+            </div>
+            <ChevronDown
+              className={`h-4 w-4 text-muted-foreground transition-transform ${subExpanded ? "rotate-180" : ""}`}
+            />
+          </button>
+          {subExpanded && (
+            <CardContent className="space-y-6 pt-0">
+              <div className="space-y-4">
+                {renderFields(subscriptionFields)}
+                <SaveButton hasChanges={hasChanges} saving={saving} onSave={onSave} />
+              </div>
+            </CardContent>
+          )}
+        </Card>
       )}
-    </Card>
+    </>
   );
 }
 
@@ -2577,6 +2616,29 @@ function FieldRow({
 }) {
   const showMasked = field.secret && field.configured && !value && !revealed;
   const isMultiline = field.key.includes("private_key") || field.key.includes("pem");
+  const isMultiselect = field.type === "multiselect" && field.options;
+
+  // For multiselect: parse comma-separated value into a Set.
+  // Priority: user-edited value > stored value (maskedValue) > all options default.
+  const selectedValues = useMemo(() => {
+    if (!isMultiselect) return new Set<string>();
+    const raw = value || field.maskedValue || "";
+    if (raw) {
+      return new Set(raw.split(",").map((v) => v.trim()).filter(Boolean));
+    }
+    // Not configured and no value — default to all options selected
+    return new Set(field.options!.map((o) => o.value));
+  }, [isMultiselect, value, field.maskedValue, field.options]);
+
+  const handleCheckboxToggle = (optionValue: string, checked: boolean) => {
+    const next = new Set(selectedValues);
+    if (checked) {
+      next.add(optionValue);
+    } else {
+      next.delete(optionValue);
+    }
+    onValueChange(Array.from(next).join(","));
+  };
 
   return (
     <div className="space-y-1.5">
@@ -2596,42 +2658,63 @@ function FieldRow({
       {field.description && (
         <p className="text-xs text-muted-foreground">{field.description}</p>
       )}
-      <div className="flex gap-2">
-        {isMultiline && !showMasked ? (
-          <Textarea
-            id={field.key}
-            value={value}
-            onChange={(e) => onValueChange(e.target.value)}
-            placeholder={field.placeholder ?? undefined}
-            className="min-h-[80px] font-mono text-sm"
-            rows={4}
-          />
-        ) : (
-          <Input
-            id={field.key}
-            type={field.secret && !revealed ? "password" : "text"}
-            value={showMasked ? (field.maskedValue ?? "") : value}
-            onChange={(e) => onValueChange(e.target.value)}
-            placeholder={field.placeholder ?? undefined}
-            disabled={showMasked}
-            className="font-mono text-sm"
-          />
-        )}
-        {field.secret && (
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={onToggleReveal}
-            type="button"
-          >
-            {revealed ? (
-              <EyeOff className="h-4 w-4" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-          </Button>
-        )}
-      </div>
+
+      {isMultiselect ? (
+        <div className="space-y-2 pt-1">
+          {field.options!.map((option) => (
+            <label
+              key={option.value}
+              className="flex items-center gap-2 cursor-pointer"
+            >
+              <Checkbox
+                checked={selectedValues.has(option.value)}
+                onCheckedChange={(checked) =>
+                  handleCheckboxToggle(option.value, checked === true)
+                }
+              />
+              <span className="text-sm">{option.label}</span>
+            </label>
+          ))}
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          {isMultiline && !showMasked ? (
+            <Textarea
+              id={field.key}
+              value={value}
+              onChange={(e) => onValueChange(e.target.value)}
+              placeholder={field.placeholder ?? undefined}
+              className="min-h-[80px] font-mono text-sm"
+              rows={4}
+            />
+          ) : (
+            <Input
+              id={field.key}
+              type={field.secret && !revealed ? "password" : "text"}
+              value={showMasked ? (field.maskedValue ?? "") : (value || (!field.secret && field.maskedValue ? field.maskedValue : ""))}
+              onChange={(e) => onValueChange(e.target.value)}
+              placeholder={field.placeholder ?? undefined}
+              disabled={showMasked}
+              className="font-mono text-sm"
+            />
+          )}
+          {field.secret && (
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onToggleReveal}
+              type="button"
+            >
+              {revealed ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </Button>
+          )}
+        </div>
+      )}
+
       {field.updatedAt && (
         <p className="text-xs text-muted-foreground">
           Last updated {timeAgo(field.updatedAt)}

--- a/workers/dashboard/worker/index.ts
+++ b/workers/dashboard/worker/index.ts
@@ -49,6 +49,7 @@ interface ConnectorField {
   secret: boolean;
   placeholder?: string;
   description?: string;
+  category?: "credential" | "subscription";
 }
 
 interface ConnectorConfig {
@@ -87,6 +88,7 @@ const CONNECTOR_CONFIGS: Record<string, ConnectorConfig> = {
         label: "Repos (comma-separated)",
         secret: false,
         placeholder: "org/repo1,org/repo2",
+        category: "subscription",
       },
       { name: "ADMIN_SECRET", label: "Admin Secret", secret: true },
     ],
@@ -97,7 +99,7 @@ const CONNECTOR_CONFIGS: Record<string, ConnectorConfig> = {
     fields: [
       { name: "SLACK_BOT_TOKEN", label: "Bot Token", secret: true, placeholder: "xoxb-..." },
       { name: "SLACK_SIGNING_SECRET", label: "Signing Secret", secret: true },
-      { name: "IGNORE_BOTS", label: "Ignore Bot Messages", secret: false, placeholder: "true (default) — set to false to include bot messages" },
+      { name: "IGNORE_BOTS", label: "Ignore Bot Messages", secret: false, placeholder: "true (default) — set to false to include bot messages", category: "subscription" },
       { name: "ADMIN_SECRET", label: "Admin Secret", secret: true },
     ],
   },
@@ -195,12 +197,14 @@ const CONNECTOR_CONFIGS: Record<string, ConnectorConfig> = {
         label: "Monitored Accounts (comma-separated)",
         secret: false,
         placeholder: "account1,account2",
+        category: "subscription",
       },
       {
         name: "X_SEARCH_QUERIES",
         label: "Search Queries (comma-separated)",
         secret: false,
         placeholder: '"my product",#myhashtag',
+        category: "subscription",
       },
       { name: "ADMIN_SECRET", label: "Admin Secret", secret: true },
     ],
@@ -269,6 +273,22 @@ const CONNECTOR_CONFIGS: Record<string, ConnectorConfig> = {
         label: "Projects (comma-separated)",
         secret: false,
         placeholder: "PROJ1,PROJ2",
+        category: "subscription",
+      },
+      {
+        name: "JIRA_EVENT_TYPES",
+        label: "Event Types",
+        secret: false,
+        category: "subscription",
+        type: "multiselect" as const,
+        options: [
+          { value: "issues", label: "Issues (created & updated)" },
+          { value: "transitions", label: "Status transitions" },
+          { value: "comments", label: "Comments" },
+          { value: "sprints", label: "Sprint changes" },
+        ],
+        description:
+          "Which Jira event types to ingest. All are selected by default.",
       },
       { name: "ADMIN_SECRET", label: "Admin Secret", secret: true },
     ],
@@ -312,6 +332,21 @@ const CONNECTOR_CONFIGS: Record<string, ConnectorConfig> = {
         label: "JPD Projects (comma-separated)",
         secret: false,
         placeholder: "JPD1,JPD2",
+        category: "subscription",
+      },
+      {
+        name: "JPD_EVENT_TYPES",
+        label: "Event Types",
+        secret: false,
+        category: "subscription",
+        type: "multiselect" as const,
+        options: [
+          { value: "ideas", label: "Ideas (created & updated)" },
+          { value: "changes", label: "Status & field changes" },
+          { value: "comments", label: "Comments" },
+        ],
+        description:
+          "Which JPD event types to ingest. All are selected by default.",
       },
       { name: "ADMIN_SECRET", label: "Admin Secret", secret: true },
     ],
@@ -333,6 +368,23 @@ const CONNECTOR_CONFIGS: Record<string, ConnectorConfig> = {
         label: "Service Desk Projects (comma-separated)",
         secret: false,
         placeholder: "SD,ITSM",
+        category: "subscription",
+      },
+      {
+        name: "JSM_EVENT_TYPES",
+        label: "Event Types",
+        secret: false,
+        category: "subscription",
+        type: "multiselect" as const,
+        options: [
+          { value: "requests", label: "Requests (created & updated)" },
+          { value: "transitions", label: "Status transitions" },
+          { value: "comments", label: "Comments" },
+          { value: "sla", label: "SLA breaches" },
+          { value: "csat", label: "CSAT feedback" },
+        ],
+        description:
+          "Which JSM event types to ingest. All are selected by default.",
       },
       { name: "ADMIN_SECRET", label: "Admin Secret", secret: true },
     ],
@@ -1848,8 +1900,13 @@ async function handleGetConnectionSettings(
         placeholder: field.placeholder || null,
         description: field.description ?? null,
         configured: metadata !== null,
-        maskedValue: metadata ? maskValue(metadata) : null,
+        maskedValue: metadata
+          ? field.secret ? maskValue(metadata) : metadata
+          : null,
         updatedAt: null,
+        ...("type" in field && { type: field.type }),
+        ...("options" in field && { options: field.options }),
+        ...("category" in field && { category: field.category }),
       };
     })
   );
@@ -1883,6 +1940,12 @@ async function handleUpdateConnectionSettings(
     );
   }
 
+  // Resolve actual worker name using prefix (e.g. "openchief-internal-" instead of "openchief-")
+  const prefix = (env as Record<string, unknown>).WORKER_NAME_PREFIX as string | undefined;
+  const resolvedWorkerName = prefix
+    ? cfg.workerName.replace("openchief-connector-", `${prefix}connector-`)
+    : cfg.workerName;
+
   const validFieldNames = new Set(cfg.fields.map((f) => f.name));
   const errors: string[] = [];
   const updated: string[] = [];
@@ -1902,7 +1965,7 @@ async function handleUpdateConnectionSettings(
 
     if (fieldDef.secret) {
       // Set as a Cloudflare Worker secret via API
-      const apiUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/workers/scripts/${cfg.workerName}/secrets`;
+      const apiUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/workers/scripts/${resolvedWorkerName}/secrets`;
 
       const cfResponse = await fetch(apiUrl, {
         method: "PUT",
@@ -1923,27 +1986,30 @@ async function handleUpdateConnectionSettings(
         continue;
       }
     } else {
-      // Set as a plain text environment variable via Worker settings API
-      // For non-secret vars, we use the settings endpoint
-      const settingsUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/workers/scripts/${cfg.workerName}/settings`;
+      // Set as a plain text environment variable via Worker settings API.
+      // The Cloudflare settings PATCH endpoint requires multipart/form-data.
+      const settingsUrl = `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/workers/scripts/${resolvedWorkerName}/settings`;
+
+      const formData = new FormData();
+      formData.append(
+        "settings",
+        JSON.stringify({
+          bindings: [
+            {
+              type: "plain_text",
+              name: fieldName,
+              text: value.trim(),
+            },
+          ],
+        })
+      );
 
       const cfResponse = await fetch(settingsUrl, {
         method: "PATCH",
         headers: {
           Authorization: `Bearer ${env.CF_API_TOKEN}`,
-          "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          settings: {
-            bindings: [
-              {
-                type: "plain_text",
-                name: fieldName,
-                text: value.trim(),
-              },
-            ],
-          },
-        }),
+        body: formData,
       });
 
       if (!cfResponse.ok) {
@@ -3185,6 +3251,16 @@ async function handleCreateTask(
     )
     .run();
 
+  // Trigger instant task execution on the assigned agent
+  if (body.assignedTo && env.AGENT_RUNTIME) {
+    env.AGENT_RUNTIME.fetch(
+      `https://runtime/trigger-task/${body.assignedTo}`,
+      { method: "POST", headers: runtimeHeaders(env) },
+    ).catch(err => {
+      console.error("Failed to trigger instant task execution:", err);
+    });
+  }
+
   return json({ id: taskId }, 201);
 }
 
@@ -3246,6 +3322,22 @@ async function handleUpdateTask(
   )
     .bind(...params)
     .run();
+
+  // Trigger instant task execution when a task is approved (status -> "queued")
+  if (body.status === "queued" && env.AGENT_RUNTIME) {
+    const taskData = await env.DB.prepare(
+      "SELECT assigned_to FROM tasks WHERE id = ?",
+    ).bind(taskId).first<{ assigned_to: string | null }>();
+
+    if (taskData?.assigned_to) {
+      env.AGENT_RUNTIME.fetch(
+        `https://runtime/trigger-task/${taskData.assigned_to}`,
+        { method: "POST", headers: runtimeHeaders(env) },
+      ).catch(err => {
+        console.error("Failed to trigger instant task execution:", err);
+      });
+    }
+  }
 
   return json({ ok: true });
 }

--- a/workers/runtime/src/agent-do.ts
+++ b/workers/runtime/src/agent-do.ts
@@ -17,7 +17,7 @@ import { buildTaskExecutionPrompt } from "./task-prompt";
 import { getAgentTools, executeTool } from "./agent-tools";
 import type { ToolDefinition } from "./agent-tools";
 import { retrieveContext, indexReport } from "./rag";
-import { postReportToSlack, postTaskProposalToSlack } from "./slack-post";
+import { postReportToSlack, postTaskProposalToSlack, postTaskCompletionToSlack } from "./slack-post";
 
 // ---------------------------------------------------------------------------
 // Staggered report schedule
@@ -1675,6 +1675,32 @@ export class AgentDurableObject extends DurableObject<Env> {
       console.log(
         `Task completed: "${task.title}" by ${config.id} (${tokensUsed} tokens)`
       );
+
+      // Post task completion to Slack (non-blocking)
+      if (config.slackChannelId) {
+        this.ctx.waitUntil(
+          (async () => {
+            try {
+              const slackToken = await this.env.KV.get("connector-secret:slack:SLACK_BOT_TOKEN");
+              if (!slackToken) return;
+              await postTaskCompletionToSlack(
+                slackToken,
+                config.slackChannelId!,
+                {
+                  title: task.title,
+                  startedAt: now,
+                  completedAt,
+                  tokensUsed,
+                },
+                output,
+                config.name
+              );
+            } catch (err) {
+              console.error("Failed to post task completion to Slack:", err);
+            }
+          })()
+        );
+      }
     } catch (err) {
       console.error(`Task execution failed for "${task.title}":`, err);
       // Revert to queued so it can be retried next hour

--- a/workers/runtime/src/slack-post.ts
+++ b/workers/runtime/src/slack-post.ts
@@ -363,3 +363,180 @@ export async function postTaskProposalToSlack(
     console.error(`Slack task proposal post error: ${result.error}`);
   }
 }
+
+/**
+ * Split markdown content into logical sections for Slack thread replies.
+ * Groups content by markdown headers, keeping each section manageable.
+ * Falls back to paragraph splitting if no headers found.
+ */
+function splitContentSections(content: string): string[] {
+  const converted = markdownToSlackMrkdwn(content);
+  const sections: string[] = [];
+
+  // Try splitting by markdown headers (now *bold lines* after conversion)
+  // Match lines that are standalone bold text (converted from # headers)
+  const lines = converted.split("\n");
+  let current = "";
+
+  for (const line of lines) {
+    // Detect section boundaries: bold-only lines that were headers
+    const isSectionHeader = /^\*[^*]+\*$/.test(line.trim()) && current.trim().length > 0;
+
+    if (isSectionHeader) {
+      if (current.trim()) {
+        sections.push(current.trim());
+      }
+      current = line;
+    } else {
+      current += (current ? "\n" : "") + line;
+    }
+  }
+  if (current.trim()) {
+    sections.push(current.trim());
+  }
+
+  // If we only got one big section (no headers), split by double-newlines
+  if (sections.length <= 1 && converted.length > MAX_BLOCK_TEXT) {
+    const paragraphs = converted.split("\n\n").filter((p) => p.trim());
+    // Group small paragraphs together, split large ones
+    const grouped: string[] = [];
+    let chunk = "";
+    for (const para of paragraphs) {
+      const candidate = chunk ? `${chunk}\n\n${para}` : para;
+      if (candidate.length > MAX_BLOCK_TEXT && chunk) {
+        grouped.push(chunk.trim());
+        chunk = para;
+      } else {
+        chunk = candidate;
+      }
+    }
+    if (chunk.trim()) grouped.push(chunk.trim());
+    return grouped;
+  }
+
+  // Further split any sections that exceed the block limit
+  const result: string[] = [];
+  for (const section of sections) {
+    if (section.length <= MAX_BLOCK_TEXT) {
+      result.push(section);
+    } else {
+      // Split oversized section at paragraph boundaries
+      const paras = section.split("\n\n");
+      let chunk = "";
+      for (const para of paras) {
+        const candidate = chunk ? `${chunk}\n\n${para}` : para;
+        if (candidate.length > MAX_BLOCK_TEXT && chunk) {
+          result.push(chunk.trim());
+          chunk = para.length > MAX_BLOCK_TEXT ? para.slice(0, MAX_BLOCK_TEXT) : para;
+        } else if (candidate.length > MAX_BLOCK_TEXT) {
+          result.push(para.slice(0, MAX_BLOCK_TEXT));
+          chunk = "";
+        } else {
+          chunk = candidate;
+        }
+      }
+      if (chunk.trim()) result.push(chunk.trim());
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Post a task completion notification to Slack.
+ * Parent message: structured block-kit with summary + metadata.
+ * Thread replies: content split by section, one message per section.
+ */
+export async function postTaskCompletionToSlack(
+  token: string,
+  channelId: string,
+  task: {
+    title: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    tokensUsed: number;
+  },
+  output: {
+    summary: string;
+    content: string;
+    artifacts: Array<{ name: string; type: string; content: string }>;
+  },
+  agentName: string,
+): Promise<void> {
+  // Calculate duration if both timestamps exist
+  let durationStr = "";
+  if (task.startedAt && task.completedAt) {
+    const durationMs =
+      new Date(task.completedAt).getTime() -
+      new Date(task.startedAt).getTime();
+    const minutes = Math.round(durationMs / 60000);
+    durationStr = minutes < 1 ? "< 1 min" : `${minutes} min`;
+  }
+
+  const metaParts = [`Completed by *${agentName}*`];
+  if (durationStr) metaParts.push(durationStr);
+  if (task.tokensUsed > 0) metaParts.push(`${task.tokensUsed.toLocaleString()} tokens`);
+
+  // Build block-kit parent message (structured like task proposals)
+  const fallbackText = `:white_check_mark: Task Completed: ${task.title} — ${output.summary}`;
+  const blocks = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:white_check_mark: *Task Completed*\n*${task.title}*`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: markdownToSlackMrkdwn(output.summary).slice(0, MAX_BLOCK_TEXT),
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: metaParts.join(" · "),
+        },
+      ],
+    },
+  ];
+
+  const response = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ channel: channelId, text: fallbackText, blocks }),
+  });
+
+  const parent = (await response.json()) as {
+    ok: boolean;
+    ts?: string;
+    error?: string;
+  };
+  if (!parent.ok || !parent.ts) {
+    console.error(`Failed to post task completion to Slack: ${parent.error}`);
+    return;
+  }
+
+  // Post content as threaded replies, split by section
+  if (output.content && output.content.length > 0) {
+    const sections = splitContentSections(output.content);
+    for (const section of sections) {
+      if (section.trim()) {
+        await postToSlack(token, channelId, section, parent.ts);
+      }
+    }
+  }
+
+  // Post each artifact as a separate thread reply
+  for (const artifact of output.artifacts) {
+    const artifactText = `:page_facing_up: *${artifact.name}* (${artifact.type})\n\`\`\`\n${artifact.content.slice(0, MAX_BLOCK_TEXT)}\n\`\`\``;
+    await postToSlack(token, channelId, artifactText, parent.ts);
+  }
+}


### PR DESCRIPTION
## Summary
- **Configurable event types** — Jira, JPD, and JSM connectors now support per-event-type filtering via multiselect checkboxes on the connection detail page
- **Split connector settings UI** — Connection detail page separates Credentials (API keys, tokens) from Subscription settings (projects, event types) into distinct collapsible cards
- **Instant task execution** — Approving a task in Slack or queuing via dashboard triggers immediate execution instead of waiting for the next hourly alarm
- **Improved Slack formatting** — Task completion messages use proper block-kit structure with section/context blocks, and content is split into threaded replies by section instead of one wall of text
- **Worker name prefix fix** — Connector settings API now correctly resolves the configured worker name prefix (e.g. `openchief-internal-`) instead of hardcoded `openchief-`

## Test plan
- [ ] Configure Jira/JPD/JSM connections with specific event types selected, verify only those event types are ingested on backfill
- [ ] Verify Credentials and Subscription sections render correctly on connection detail pages
- [ ] Approve a task in Slack and confirm it executes immediately
- [ ] Queue a task via dashboard and confirm instant execution
- [ ] Trigger a task completion and verify Slack message uses block-kit with threaded sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)